### PR TITLE
Fix cumulative year-to-date values in treemap

### DIFF
--- a/src/callbacks/callback_treemap.py
+++ b/src/callbacks/callback_treemap.py
@@ -31,7 +31,6 @@ from utils.fetch_treemap import (
     ClassifiedSpendingData,
     TreemapDataFetcher,
     fetch_treemap_hierarchy,
-    find_prev_report_budget_id,
 )
 from utils.transform_treemap import TreemapTransformer
 
@@ -68,27 +67,6 @@ def transform_treemap_data(
         df = transformer.transform_from_flat(flat_rows)
     else:
         df = transformer.transform_data()
-    if (
-        unit in {"PERCENT_YEAR_TO_DATE_SPENDING", "PERCENT_YEAR_TO_DATE_REVENUE"}
-        and budget_type == "REPORT"
-        and published_at.month > 3
-    ):
-        prev_budget_id = find_prev_report_budget_id(
-            year=published_at.year, month=published_at.month - 3
-        )
-        if prev_budget_id is not None:
-            prev_dims, prev_progs, prev_classified, _ = fetch_treemap_data(prev_budget_id)
-            prev_transformer = TreemapTransformer(
-                prev_dims, prev_progs, prev_classified, spending_type=spending_type
-            )
-            prev_flat = fetch_treemap_hierarchy(prev_budget_id)
-            prev_df = (
-                prev_transformer.transform_from_flat(prev_flat)
-                if prev_flat
-                else prev_transformer.transform_data()
-            )
-            df = transformer.subtract_prev_quarter(df, prev_df)
-
     calculator = Calculator(unit, budget_id, published_at, budget_type)
     df["VALUE"] = calculator.calculate_series(df["VALUE"]).clip(lower=0)
     return df

--- a/tests/test_treemap_ytd_unit.py
+++ b/tests/test_treemap_ytd_unit.py
@@ -1,0 +1,59 @@
+"""Regression tests for cumulative year-to-date values in the treemap."""
+
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from callbacks import callback_treemap
+
+
+@pytest.mark.parametrize(
+    "unit",
+    ["PERCENT_YEAR_TO_DATE_SPENDING", "PERCENT_YEAR_TO_DATE_REVENUE"],
+)
+def test_report_ytd_treemap_keeps_cumulative_values(monkeypatch, unit: str) -> None:
+    """YTD treemaps must use the same cumulative numerator as their denominator."""
+
+    class FakeTransformer:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def transform_from_flat(self, _rows) -> pd.DataFrame:
+            return pd.DataFrame({"VALUE": [150.0]})
+
+        def subtract_prev_quarter(
+            self, _current: pd.DataFrame, _previous: pd.DataFrame
+        ) -> pd.DataFrame:
+            return pd.DataFrame({"VALUE": [50.0]})
+
+    class IdentityCalculator:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def calculate_series(self, series: pd.Series) -> pd.Series:
+            return series
+
+    monkeypatch.setattr(
+        callback_treemap,
+        "fetch_treemap_data",
+        lambda _budget_id: ([{"budget_type": "REPORT"}], [], None, date(2024, 6, 30)),
+    )
+    monkeypatch.setattr(
+        callback_treemap,
+        "fetch_treemap_hierarchy",
+        lambda _budget_id: [{"value": 150.0}],
+    )
+    monkeypatch.setattr(
+        callback_treemap, "find_prev_report_budget_id", lambda **_kwargs: 1, raising=False
+    )
+    monkeypatch.setattr(callback_treemap, "TreemapTransformer", FakeTransformer)
+    monkeypatch.setattr(callback_treemap, "Calculator", IdentityCalculator)
+
+    callback_treemap.transform_treemap_data.cache_clear()
+    try:
+        result = callback_treemap.transform_treemap_data(2, "ALL", unit)
+    finally:
+        callback_treemap.transform_treemap_data.cache_clear()
+
+    assert result["VALUE"].tolist() == [150.0]


### PR DESCRIPTION
## Summary

- keep report treemap values cumulative for year-to-date spending and revenue
- align treemap calculations with the time series and their cumulative denominators
- remove the previous-quarter subtraction that converted the numerator to a quarter-only value
- leave GDP year-to-date logic unchanged; missing GDP periods are a data-completeness issue

## Root cause

For reports after Q1, `transform_treemap_data` subtracted the previous report before passing values to `Calculator`. The numerator therefore represented only the latest quarter, while the spending or revenue denominator remained cumulative year-to-date. This understated treemap percentages and made them inconsistent with the time series.

## Tests

- `python -m pytest tests/test_treemap_ytd_unit.py -q -p no:cacheprovider` — 2 passed
